### PR TITLE
Use default yeast percentage

### DIFF
--- a/calculator/app/views/static/index.html.erb
+++ b/calculator/app/views/static/index.html.erb
@@ -36,7 +36,6 @@
           max: "99"
         )
       ) %>
-      <input type="hidden" name="yeast" value="0.0015">
 
       <div class="form-group">
         <label class="form-label" for="dough_type">Dough type</label>


### PR DESCRIPTION
Reverts a change introduced in https://github.com/hendricius/pizza-dough/commit/d0b59eb51d30f45f00d1ca5bc5c9ad7f68869f9f, where the dry yeast value used by the calculator's main form was set to 0.15%, contradicting the 0.05% mentioned in the guide: https://github.com/hendricius/pizza-dough/blob/0d12ee9d0f84b26f8d3335bdfd35a1e22b0b8e80/README.md#L43

As well as in `dough.rb`: https://github.com/hendricius/pizza-dough/blob/0d12ee9d0f84b26f8d3335bdfd35a1e22b0b8e80/calculator/app/services/dough.rb#L5